### PR TITLE
Update arm packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,10 @@ RUN apt-get -q update \
         dkms \
         gfortran \
         libblas-dev \
+        libffi-dev \
         liblapack-dev \
         libpcap-dev \
+        libssl-dev \
         python-all \
         python-apt \
         python-cffi \


### PR DESCRIPTION
libffi-dev and libssl-dev are needed to build Python libraries.

Signed-off-by: juraj.linkes <juraj.linkes@pantheon.tech>